### PR TITLE
Update aws-matlab-2019b-template.json

### DIFF
--- a/releases/R2019b/aws-matlab-2019b-template.json
+++ b/releases/R2019b/aws-matlab-2019b-template.json
@@ -140,7 +140,7 @@
         },
         "Password": {
             "NoEcho": "true",
-            "Description": "Enter a password for the username",
+            "Description": "Enter a password for the username. Enclose within single quotes or escape special characters individually using backslashes.",
             "Type": "String",
             "ConstraintDescription": "",
             "Default": ""


### PR DESCRIPTION
Provide notice to users when inputting passwords with special characters. The password fields do not handle special characters which can break the **echo** command and insert an invalid/unusable password.

The reason for not hardcoding single quotes around the password is to allow for passwords containing single quote characters.