### PR TITLE
Pushing the sudo fix for matlab 19a aws

### DIFF
--- a/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template-eu-west-1.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template-eu-west-1.json
@@ -133,11 +133,11 @@
         "MaxValue": "65535"
       },
       "SuppressSecurityUpdates": {
-        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
         "Type": "String",
         "Default": "No",
         "AllowedPattern": "(?:Yes|No)",
-        "ConstraintDescription": "If specified, must be either No or Yes"
+        "ConstraintDescription": "Must be either 'No' or 'Yes'"
       }
     },
     "Rules" : {

--- a/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template-eu-west-1.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template-eu-west-1.json
@@ -32,6 +32,14 @@
               "default": "Remote Access"
             },
             "Parameters": ["ClientIPAddress", "SSHKeyName", "Username", "Password", "ConfirmPassword"]
+          },
+          {
+            "Label": {
+              "default": "Un-attended Security Updates"
+            },
+            "Parameters": [
+              "SuppressSecurityUpdates"
+            ]
           }
         ],
         "ParameterLabels": {
@@ -49,6 +57,9 @@
           },
           "password": {
             "default": "password"
+          },
+          "SuppressSecurityUpdates": {
+            "default": "Suppress critical security updates"
           }
         }
       }
@@ -120,6 +131,13 @@
         "Default": "27000",
         "MinValue": "0",
         "MaxValue": "65535"
+      },
+      "SuppressSecurityUpdates": {
+        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+        "Type": "String",
+        "Default": "No",
+        "AllowedPattern": "(?:Yes|No)",
+        "ConstraintDescription": "If specified, must be either No or Yes"
       }
     },
     "Rules" : {
@@ -212,7 +230,16 @@
                   "\n",
                   "sudo usermod -aG sudo ",
                   { "Ref" : "Username" },
-                  "\n"
+                  "\n",
+                  "if [ 'No' == '",
+                  { "Ref": "SuppressSecurityUpdates" },
+                  "' ]\n",
+                  " then \n",
+                  "#install unattended-upgrades\n",
+                  "sudo apt-get update --fix-missing\n",
+                  "sudo apt-get install unattended-upgrades\n",
+                  "\n",
+                  "fi\n"
                 ]
               ]
             }
@@ -228,5 +255,4 @@
           }
       }
     }
-  }
-  
+}

--- a/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template-eu-west-1.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template-eu-west-1.json
@@ -136,7 +136,7 @@
         "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
         "Type": "String",
         "Default": "No",
-        "AllowedPattern": "(?:Yes|No)",
+        "AllowedPattern": "(\bYes\b|\bNo\b)",
         "ConstraintDescription": "Must be either 'No' or 'Yes'"
       }
     },

--- a/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template.json
@@ -133,11 +133,11 @@
         "MaxValue": "65535"
       },
       "SuppressSecurityUpdates": {
-        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
         "Type": "String",
         "Default": "No",
         "AllowedPattern": "(?:Yes|No)",
-        "ConstraintDescription": "If specified, must be either No or Yes"
+        "ConstraintDescription": "Must be either 'No' or 'Yes'"
       }
     },
     "Rules" : {

--- a/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template.json
@@ -32,6 +32,14 @@
               "default": "Remote Access"
             },
             "Parameters": ["ClientIPAddress", "SSHKeyName", "Username", "Password", "ConfirmPassword"]
+          },
+          {
+            "Label": {
+              "default": "Un-attended Security Updates"
+            },
+            "Parameters": [
+              "SuppressSecurityUpdates"
+            ]
           }
         ],
         "ParameterLabels": {
@@ -49,6 +57,9 @@
           },
           "password": {
             "default": "password"
+          },
+          "SuppressSecurityUpdates": {
+            "default": "Suppress critical security updates"
           }
         }
       }
@@ -120,6 +131,13 @@
         "Default": "27000",
         "MinValue": "0",
         "MaxValue": "65535"
+      },
+      "SuppressSecurityUpdates": {
+        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+        "Type": "String",
+        "Default": "No",
+        "AllowedPattern": "(?:Yes|No)",
+        "ConstraintDescription": "If specified, must be either No or Yes"
       }
     },
     "Rules" : {
@@ -212,7 +230,16 @@
                   "\n",
                   "sudo usermod -aG sudo ",
                   { "Ref" : "Username" },
-                  "\n"
+                  "\n",
+                  "if [ 'No' == '",
+                  { "Ref": "SuppressSecurityUpdates" },
+                  "' ]\n",
+                  " then \n",
+                  "#install unattended-upgrades\n",
+                  "sudo apt-get update --fix-missing\n",
+                  "sudo apt-get install unattended-upgrades\n",
+                  "\n",
+                  "fi\n"
                 ]
               ]
             }
@@ -228,5 +255,4 @@
           }
       }
     }
-  }
-  
+}

--- a/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-license-manager-template.json
@@ -136,7 +136,7 @@
         "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
         "Type": "String",
         "Default": "No",
-        "AllowedPattern": "(?:Yes|No)",
+        "AllowedPattern": "(\bYes\b|\bNo\b)",
         "ConstraintDescription": "Must be either 'No' or 'Yes'"
       }
     },

--- a/releases/R2019a_and_older/aws-matlab-2019a-vpc-template-eu-west-1.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-vpc-template-eu-west-1.json
@@ -21,6 +21,14 @@
               "default": "Remote Access"
             },
             "Parameters": ["ClientIPAddress", "SSHKeyName", "Username", "Password", "ConfirmPassword"]
+          },
+          {
+            "Label": {
+              "default": "Un-attended Security Updates"
+            },
+            "Parameters": [
+              "SuppressSecurityUpdates"
+            ]
           }
         ],
         "ParameterLabels": {
@@ -41,6 +49,9 @@
           },
           "ConfirmPassword": {
             "default": "Confirm Password"
+          },
+          "SuppressSecurityUpdates": {
+            "default": "Suppress critical security updates"
           }
         }
       }
@@ -89,6 +100,13 @@
         "Type": "String",
         "ConstraintDescription": "",
         "Default": ""
+      },
+      "SuppressSecurityUpdates": {
+        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+        "Type": "String",
+        "Default": "No",
+        "AllowedPattern": "(?:Yes|No)",
+        "ConstraintDescription": "If specified, must be either No or Yes"
       }
     },
     "Rules" : {
@@ -227,7 +245,16 @@
                   "\n",
                   "sudo usermod -aG sudo ",
                   { "Ref" : "Username" },
-                  "\n"
+                  "\n",
+                  "if [ 'No' == '",
+                  { "Ref": "SuppressSecurityUpdates" },
+                  "' ]\n",
+                  " then \n",
+                  "#install unattended-upgrades\n",
+                  "sudo apt-get update --fix-missing\n",
+                  "sudo apt-get install unattended-upgrades\n",
+                  "\n",
+                  "fi\n"
                 ]
               ]
             }
@@ -243,5 +270,4 @@
           }
       }
     }
-  }
-  
+}

--- a/releases/R2019a_and_older/aws-matlab-2019a-vpc-template-eu-west-1.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-vpc-template-eu-west-1.json
@@ -105,7 +105,7 @@
         "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
         "Type": "String",
         "Default": "No",
-        "AllowedPattern": "(?:Yes|No)",
+        "AllowedPattern": "(\bYes\b|\bNo\b)",
         "ConstraintDescription": "Must be either 'No' or 'Yes'"
       }
     },

--- a/releases/R2019a_and_older/aws-matlab-2019a-vpc-template-eu-west-1.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-vpc-template-eu-west-1.json
@@ -102,11 +102,11 @@
         "Default": ""
       },
       "SuppressSecurityUpdates": {
-        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
         "Type": "String",
         "Default": "No",
         "AllowedPattern": "(?:Yes|No)",
-        "ConstraintDescription": "If specified, must be either No or Yes"
+        "ConstraintDescription": "Must be either 'No' or 'Yes'"
       }
     },
     "Rules" : {

--- a/releases/R2019a_and_older/aws-matlab-2019a-vpc-template.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-vpc-template.json
@@ -21,6 +21,14 @@
               "default": "Remote Access"
             },
             "Parameters": ["ClientIPAddress", "SSHKeyName", "Username", "Password", "ConfirmPassword"]
+          },
+          {
+            "Label": {
+              "default": "Un-attended Security Updates"
+            },
+            "Parameters": [
+              "SuppressSecurityUpdates"
+            ]
           }
         ],
         "ParameterLabels": {
@@ -41,6 +49,9 @@
           },
           "ConfirmPassword": {
             "default": "Confirm Password"
+          },
+          "SuppressSecurityUpdates": {
+            "default": "Suppress critical security updates"
           }
         }
       }
@@ -89,6 +100,13 @@
         "Type": "String",
         "ConstraintDescription": "",
         "Default": ""
+      },
+      "SuppressSecurityUpdates": {
+        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+        "Type": "String",
+        "Default": "No",
+        "AllowedPattern": "(?:Yes|No)",
+        "ConstraintDescription": "If specified, must be either No or Yes"
       }
     },
     "Rules" : {
@@ -227,7 +245,16 @@
                   "\n",
                   "sudo usermod -aG sudo ",
                   { "Ref" : "Username" },
-                  "\n"
+                  "\n",
+                  "if [ 'No' == '",
+                  { "Ref": "SuppressSecurityUpdates" },
+                  "' ]\n",
+                  " then \n",
+                  "#install unattended-upgrades\n",
+                  "sudo apt-get update --fix-missing\n",
+                  "sudo apt-get install unattended-upgrades\n",
+                  "\n",
+                  "fi\n"
                 ]
               ]
             }
@@ -243,5 +270,4 @@
           }
       }
     }
-  }
-  
+}

--- a/releases/R2019a_and_older/aws-matlab-2019a-vpc-template.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-vpc-template.json
@@ -105,7 +105,7 @@
         "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
         "Type": "String",
         "Default": "No",
-        "AllowedPattern": "(?:Yes|No)",
+        "AllowedPattern": "(\bYes\b|\bNo\b)",
         "ConstraintDescription": "Must be either 'No' or 'Yes'"
       }
     },

--- a/releases/R2019a_and_older/aws-matlab-2019a-vpc-template.json
+++ b/releases/R2019a_and_older/aws-matlab-2019a-vpc-template.json
@@ -102,11 +102,11 @@
         "Default": ""
       },
       "SuppressSecurityUpdates": {
-        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+        "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
         "Type": "String",
         "Default": "No",
         "AllowedPattern": "(?:Yes|No)",
-        "ConstraintDescription": "If specified, must be either No or Yes"
+        "ConstraintDescription": "Must be either 'No' or 'Yes'"
       }
     },
     "Rules" : {


### PR DESCRIPTION
This sudo bug fix includes the following changes to the existing CFT templates -
1. Added a new UI option `SuppressSecurityUpdates` for users to either accept and reject having the sudo bug fix automatically applied to the new stack.
2. By default the select to `SuppressSecurityUpdates` is `No`, which the fix will be applied. A user will have to explicitly select `Yes` to suppress the fix.
3. The sudo fix is being done by installing the module `unattended-upgrades` which automatically runs on every boot and only installs critical security updates.