### PR TITLE
Pushing the sudo fix for matlab 19b aws

### DIFF
--- a/releases/R2019b/aws-matlab-2019b-template.json
+++ b/releases/R2019b/aws-matlab-2019b-template.json
@@ -171,11 +171,11 @@
             "ConstraintDescription": "If specified, must be in the form <port>@<hostname>"
         },
         "SuppressSecurityUpdates": {
-          "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+          "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
           "Type": "String",
           "Default": "No",
           "AllowedPattern": "(?:Yes|No)",
-          "ConstraintDescription": "If specified, must be either No or Yes"
+          "ConstraintDescription": "Must be either 'No' or 'Yes'"
         }
     },
     "Mappings": {

--- a/releases/R2019b/aws-matlab-2019b-template.json
+++ b/releases/R2019b/aws-matlab-2019b-template.json
@@ -174,7 +174,7 @@
           "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk. Specify either 'No' or 'Yes'",
           "Type": "String",
           "Default": "No",
-          "AllowedPattern": "(?:Yes|No)",
+          "AllowedPattern": "(\bYes\b|\bNo\b)",
           "ConstraintDescription": "Must be either 'No' or 'Yes'"
         }
     },

--- a/releases/R2019b/aws-matlab-2019b-template.json
+++ b/releases/R2019b/aws-matlab-2019b-template.json
@@ -43,6 +43,14 @@
                     "Parameters": [
                         "LicenseManager"
                     ]
+                },
+                {
+                  "Label": {
+                    "default": "Un-attended Security Updates"
+                  },
+                  "Parameters": [
+                    "SuppressSecurityUpdates"
+                  ]
                 }
             ],
             "ParameterLabels": {
@@ -78,6 +86,9 @@
                 },
                 "SSHKeyName": {
                     "default": "SSH Key Pair"
+                },
+                "SuppressSecurityUpdates": {
+                  "default": "Suppress critical security updates"
                 }
             }
         }
@@ -158,6 +169,13 @@
             "Default": "",
             "AllowedPattern": "([0-9]+@[a-zA-Z0-9.]+)?",
             "ConstraintDescription": "If specified, must be in the form <port>@<hostname>"
+        },
+        "SuppressSecurityUpdates": {
+          "Description": "By default, the un-attended critical security upgrades are enabled, a user can explicitly suppress the security upgrades at their own risk.",
+          "Type": "String",
+          "Default": "No",
+          "AllowedPattern": "(?:Yes|No)",
+          "ConstraintDescription": "If specified, must be either No or Yes"
         }
     },
     "Mappings": {
@@ -348,7 +366,16 @@
                                     "Ref": "Username"
                                 },
                                 "\n",
-                                "sudo apt-get install awscli -y\n"
+                                "sudo apt-get install awscli -y\n",
+                                "if [ 'No' == '",
+                                { "Ref": "SuppressSecurityUpdates" },
+                                "' ]\n",
+                                " then \n",
+                                "#install unattended-upgrades\n",
+                                "sudo apt-get update --fix-missing\n",
+                                "sudo apt-get install unattended-upgrades\n",
+                                "\n",
+                                "fi\n"
                             ]
                         ]
                     }


### PR DESCRIPTION
This sudo bug fix includes the following changes to the existing CFT templates -
1. Added a new UI option `SuppressSecurityUpdates` for users to either accept and reject having the sudo bug fix automatically applied to the new stack.
2. By default the select to `SuppressSecurityUpdates` is `No`, which the fix will be applied. A user will have to explicitly select `Yes` to suppress the fix.
3. The sudo fix is being done by installing the module `unattended-upgrades` which automatically runs on every boot and only installs critical security updates.